### PR TITLE
fix: shutdown genserver when receiving an error

### DIFF
--- a/lib/pigeon/dispatcher_worker.ex
+++ b/lib/pigeon/dispatcher_worker.ex
@@ -40,7 +40,7 @@ defmodule Pigeon.DispatcherWorker do
         {:noreply, %{adapter: adapter, state: new_state}}
 
       {:stop, reason} ->
-        {:stop, reason, %{adapter: adapter, state: state}}
+        {:shutdown, reason, %{adapter: adapter, state: state}}
 
       {:stop, reason, new_state} ->
         {:stop, reason, %{adapter: adapter, state: new_state}}


### PR DESCRIPTION
#### Description
Avoid raising an error when stopping the genserver for an expected reason.
See: https://remotecom.sentry.io/issues/5768169472/?environment=production&project=2601089&referrer=project-issue-stream&statsPeriod=12h