### PR TITLE
fix: avoid error and remove internal state from being logged

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,5 +14,5 @@ config :pigeon, PigeonTest.APNS,
 
 config :pigeon, PigeonTest.FCM,
   adapter: Pigeon.FCM,
-  project_id: System.get_env("FCM_PROJECT"),
+  project_id: System.get_env("FCM_PROJECT_ID"),
   service_account_json: System.get_env("FCM_SERVICE_ACCOUNT_JSON")

--- a/lib/pigeon/dispatcher_worker.ex
+++ b/lib/pigeon/dispatcher_worker.ex
@@ -1,5 +1,6 @@
 defmodule Pigeon.DispatcherWorker do
   @moduledoc false
+  require Logger
 
   use GenServer
 
@@ -40,7 +41,7 @@ defmodule Pigeon.DispatcherWorker do
         {:noreply, %{adapter: adapter, state: new_state}}
 
       {:stop, reason} ->
-        {:stop, {:shutdown, {reason, %{adapter: adapter, state: state}}}}
+        {:stop, {:shutdown, reason}, %{adapter: adapter, state: state}}
 
       {:stop, reason, new_state} ->
         {:stop, reason, %{adapter: adapter, state: new_state}}


### PR DESCRIPTION
### Description
Unit testing these behaviours are really complex without a mocking library (is it worth to invest time on this?) because these errors are thrown when http calls fail.

Tested locally and looks like logging the exit but not flagging as error 🙏 

This is the exit code returned when terminating the genserver
```
** (EXIT from #PID<0.751.0>) shell process exited with reason: shutdown: {{{:badmatch, {:error, {{:badmatch, {:error, :nxdomain}}, [{Kadabra.Connection, :init, 1, [file: ~c"lib/connection.ex", line: 44]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_server, 
:init_it, 6, [file: ~c"gen_server.erl", line: 917]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}}}, [{Kadabra.ConnectionPool, :init, 1, [file: ~c"lib/connection_pool.ex", line: 59]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_se
rver, :init_it, 6, [file: ~c"gen_server.erl", line: 917]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}, {:child, :undefined, #Reference<0.870790221.1576271882.234838>, {Kadabra.ConnectionPool, :start_link, [%URI{scheme: "https", authority: "fcm.googleapis.co
m", userinfo: nil, host: "fcm.googleapis.com", port: 443, path: nil, query: nil, fragment: nil}, #PID<0.793.0>, [ssl: [{:active, :once}, {:packet, :raw}, {:reuseaddr, true}, {:alpn_advertised_protocols, ["h2"]}, :binary]]]}, :transient, false, 5000, :worker, [Kadabra.ConnectionPool]}}
```

while with the old implementation it was
```
14:18:44.181 [error] GenServer #PID<0.721.0> terminating                                                                                                                                                                                                                                      
** (stop) {{{:badmatch, {:error, {{:badmatch, {:error, :nxdomain}}, [{Kadabra.Connection, :init, 1, [file: ~c"lib/connection.ex", line: 44]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_server, :init_it, 6, [file: ~c"gen_server.erl", line: 917]}, {:proc_lib
, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}}}, [{Kadabra.ConnectionPool, :init, 1, [file: ~c"lib/connection_pool.ex", line: 59]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_server, :init_it, 6, [file: ~c"gen_server.erl", line: 917]}, {:pr
oc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}, {:child, :undefined, #Reference<0.870790221.1576271882.234701>, {Kadabra.ConnectionPool, :start_link, [%URI{scheme: "https", authority: "fcm.googleapis.com", userinfo: nil, host: "fcm.googleapis.com", port: 443, path:
 nil, query: nil, fragment: nil}, #PID<0.721.0>, [ssl: [{:active, :once}, {:packet, :raw}, {:reuseaddr, true}, {:alpn_advertised_protocols, ["h2"]}, :binary]]]}, :transient, false, 5000, :worker, [Kadabra.ConnectionPool]}}
Last message: {:closed, "123"}                                                                                                                 
State: %{state: %Pigeon.FCM{config: %Pigeon.FCM.Config{port: 443, project_id: "remote-din", service_account_json: %{"auth_provider_x509_cert_url" => "https://www.googleapis.com/oauth2/v1/certs", "auth_uri" => "https://accounts.google.com/o/oauth2/auth", "client_email" => "fcm-create@re
mote-din.iam.gserviceaccount.com", "client_id" => "105176498250071390228", "client_x509_cert_url" => "https://www.googleapis.com/robot/v1/metadata/x509/fcm-create%40remote-din.iam.gserviceaccount.com", "private_key" => "-****", "private_key_id" => "70473ac3a6f40daef430d8d2ca
1eb4a42cdffdbc", "project_id" => "remote-din", "token_uri" => "https://oauth2.googleapis.com/token", "type" => "service_account", "universe_domain" => "googleapis.com"}, uri: ~c"fcm.googleapis.com"}, queue: %{}, refresh_before: 300, retries: 3, socket: #PID<0.722.0>, stream_id: 1, toke
n: %Goth.Token{token: "*******", type: "Bearer", scope: "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.
com/auth/firebase.messaging", sub: nil, expires: 1725023919, account: nil}}, adapter: Pigeon.FCM}                                              
** (EXIT from #PID<0.720.0>) shell process exited with reason: {{{:badmatch, {:error, {{:badmatch, {:error, :nxdomain}}, [{Kadabra.Connection, :init, 1, [file: ~c"lib/connection.ex", line: 44]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_server, :init_it, 
6, [file: ~c"gen_server.erl", line: 917]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}}}, [{Kadabra.ConnectionPool, :init, 1, [file: ~c"lib/connection_pool.ex", line: 59]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 962]}, {:gen_server, :ini
t_it, 6, [file: ~c"gen_server.erl", line: 917]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 241]}]}, {:child, :undefined, #Reference<0.870790221.1576271882.234701>, {Kadabra.ConnectionPool, :start_link, [%URI{scheme: "https", authority: "fcm.googleapis.com", userin
fo: nil, host: "fcm.googleapis.com", port: 443, path: nil, query: nil, fragment: nil}, #PID<0.721.0>, [ssl: [{:active, :once}, {:packet, :raw}, {:reuseaddr, true}, {:alpn_advertised_protocols, ["h2"]}, :binary]]]}, :transient, false, 5000, :worker, [Kadabra.ConnectionPool]}}
```